### PR TITLE
Add react-scripts and other required dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,15 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.0",
+    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^13.5.0",
     "firebase": "^10.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.20.0"
+    "react-router-dom": "^6.20.0",
+    "react-scripts": "5.0.1",
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
- Added react-scripts dependency
- Added testing libraries
- Added web-vitals

This fixes the npm start command by adding the required dependencies.